### PR TITLE
Linux Socket Receive시 Crush 오류 수정

### DIFF
--- a/example/1.simple/CGDK.asio.simple_client.vs17.sln
+++ b/example/1.simple/CGDK.asio.simple_client.vs17.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.asio.tcp_echo_client", "client\CGDK.asio.tcp_echo_client.vs17.vcxproj", "{0B403609-7EBB-4427-AD32-69A9882E0F59}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.asio.tcp_echo_client", "client\CGDK.asio.simple_tcp_client.vs17.vcxproj", "{0B403609-7EBB-4427-AD32-69A9882E0F59}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/example/1.simple/CGDK.asio.simple_server.vs17.sln
+++ b/example/1.simple/CGDK.asio.simple_server.vs17.sln
@@ -3,7 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.asio.example.simple_tcp.server", "server\CGDK.asio.simple_tcp_server.vs17.vcxproj", "{6947CA3F-BA21-4747-9301-26F1EE9E1649}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Debug|x64.ActiveCfg = Debug|x64
+		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Debug|x64.Build.0 = Debug|x64
+		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Release|x64.ActiveCfg = Release|x64
+		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/example/2.tcp_echo_test/CGDK.asio.tcp_echo_client.vs17.sln
+++ b/example/2.tcp_echo_test/CGDK.asio.tcp_echo_client.vs17.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.asio.tcp_echo_client", "..\1.simple\client\CGDK.asio.simple_tcp_client.vs17.vcxproj", "{0B403609-7EBB-4427-AD32-69A9882E0F59}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.tcp_echo_client.asio.console", "client\CGDK.asio.tcp_echo_client.vs17.vcxproj", "{0B403609-7EBB-4427-AD32-69A9882E0F59}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/example/2.tcp_echo_test/CGDK.asio.tcp_echo_server.vs17.sln
+++ b/example/2.tcp_echo_test/CGDK.asio.tcp_echo_server.vs17.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.asio.example.simple_tcp.server", "..\1.simple\server\CGDK.asio.simple_tcp_server.vs17.vcxproj", "{6947CA3F-BA21-4747-9301-26F1EE9E1649}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGDK.tcp_echo_server.asio.console", "server\CGDK.asio.tcp_echo_server.vs17.vcxproj", "{0F220B3D-340D-472B-8CA6-1D2070D69E61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Debug|x64.ActiveCfg = Debug|x64
-		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Debug|x64.Build.0 = Debug|x64
-		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Release|x64.ActiveCfg = Release|x64
-		{6947CA3F-BA21-4747-9301-26F1EE9E1649}.Release|x64.Build.0 = Release|x64
+		{0F220B3D-340D-472B-8CA6-1D2070D69E61}.Debug|x64.ActiveCfg = Debug|x64
+		{0F220B3D-340D-472B-8CA6-1D2070D69E61}.Debug|x64.Build.0 = Debug|x64
+		{0F220B3D-340D-472B-8CA6-1D2070D69E61}.Release|x64.ActiveCfg = Release|x64
+		{0F220B3D-340D-472B-8CA6-1D2070D69E61}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/example/2.tcp_echo_test/client/CGDK.asio.tcp_echo_client.vs17.vcxproj
+++ b/example/2.tcp_echo_test/client/CGDK.asio.tcp_echo_client.vs17.vcxproj
@@ -11,11 +11,11 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="CGDK.asio.tcp_echo_server.cpp" />
-    <ClCompile Include="echo_client.cpp" />
+    <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Text Include="CMakeLists.txt" />
+    <ClCompile Include="CGDK.asio.tcp_echo_client.cpp" />
+    <ClCompile Include="echo_client.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="echo_client.h" />
@@ -26,7 +26,7 @@
     <ProjectGuid>{0b403609-7ebb-4427-ad32-69a9882e0f59}</ProjectGuid>
     <RootNamespace>tcpechoclientasioconsole</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>CGDK10.tcp_echo_client.asio.console</ProjectName>
+    <ProjectName>CGDK.tcp_echo_client.asio.console</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/example/2.tcp_echo_test/client/CGDK.asio.tcp_echo_client.vs17.vcxproj.filters
+++ b/example/2.tcp_echo_test/client/CGDK.asio.tcp_echo_client.vs17.vcxproj.filters
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="CGDK.asio.tcp_echo_server.cpp" />
-    <ClCompile Include="echo_client.cpp" />
+    <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Text Include="CMakeLists.txt" />
+    <ClCompile Include="CGDK.asio.tcp_echo_client.cpp" />
+    <ClCompile Include="echo_client.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="echo_client.h" />

--- a/example/2.tcp_echo_test/server/CGDK.asio.tcp_echo_server.vs17.vcxproj
+++ b/example/2.tcp_echo_test/server/CGDK.asio.tcp_echo_server.vs17.vcxproj
@@ -10,13 +10,17 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CGDK.asio.tcp_echo_server.cpp" />
+    <ClCompile Include="CGDK.asio.tcp_echo_server.ex.cpp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{0f220b3d-340d-472b-8ca6-1d2070d69e61}</ProjectGuid>
     <RootNamespace>tcpechoserverboostconsole</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>CGDK10.tcp_echo_server.asio.console</ProjectName>
+    <ProjectName>CGDK.tcp_echo_server.asio.console</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -104,10 +108,6 @@
       <AdditionalLibraryDirectories>..\..\..\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="CGDK.asio.tcp_echo_server.console.cpp" />
-    <ClCompile Include="CGDK.asio.tcp_echo_server.console.ex.cpp" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/example/2.tcp_echo_test/server/CGDK.asio.tcp_echo_server.vs17.vcxproj.filters
+++ b/example/2.tcp_echo_test/server/CGDK.asio.tcp_echo_server.vs17.vcxproj.filters
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="CGDK.asio.tcp_echo_server.console.cpp" />
-    <ClCompile Include="CGDK.asio.tcp_echo_server.console.ex.cpp" />
+    <ClCompile Include="CGDK.asio.tcp_echo_server.cpp" />
+    <ClCompile Include="CGDK.asio.tcp_echo_server.ex.cpp" />
   </ItemGroup>
 </Project>

--- a/src/Isocket_tcp.cpp
+++ b/src/Isocket_tcp.cpp
@@ -64,6 +64,9 @@ void CGDK::asio::Isocket_tcp::process_connective_closesocket() noexcept
 
 bool CGDK::asio::Isocket_tcp::process_close_native_handle() noexcept
 {
+	// lock) 
+	std::lock_guard cs(m_lock_socket);
+
 	// check) 
 	if (this->m_socket.is_open() == false)
 		return false;

--- a/src/Isocket_tcp.cpp
+++ b/src/Isocket_tcp.cpp
@@ -49,7 +49,7 @@ void CGDK::asio::Isocket_tcp::process_connective_closesocket() noexcept
 	// 1) get connective
 	{
 		// lock) 
-		std::lock_guard cs(m_lock_socket);
+		std::lock_guard cs(this->m_lock_socket);
 
 		// check) 
 		if (!this->m_pconnective)
@@ -65,7 +65,7 @@ void CGDK::asio::Isocket_tcp::process_connective_closesocket() noexcept
 bool CGDK::asio::Isocket_tcp::process_close_native_handle() noexcept
 {
 	// lock) 
-	std::lock_guard cs(m_lock_socket);
+	std::lock_guard cs(this->m_lock_socket);
 
 	// check) 
 	if (this->m_socket.is_open() == false)

--- a/src/Nsocket_tcp.cpp
+++ b/src/Nsocket_tcp.cpp
@@ -299,6 +299,11 @@ void CGDK::asio::Nsocket_tcp::process_receive_async()
 			}
 			catch (...)
 			{
+				// - close socket 
+				this->process_closesocket(boost::asio::error::operation_aborted);
+
+				// - release
+				this->m_hold_async.reset();
 			}
 		});
 }

--- a/src/Nsocket_tcp.cpp
+++ b/src/Nsocket_tcp.cpp
@@ -165,6 +165,13 @@ void CGDK::asio::Nsocket_tcp::process_receive_async()
 	// 2) hold receiving buffer(비동기 receive 처기가 완료 될 때까지 buffer가 할당해제 되지 않도록 하기 위해 hold)
 	this->m_hold_receiving = this->m_received_msg.get_source();
 
+	// lock) 
+	std::lock_guard cs(this->m_lock_socket);
+
+	// check) 
+	if (this->m_socket.is_open() == false)
+		throw std::runtime_error("socket closed");
+
 	// 3) send async
 	this->m_socket.async_read_some(this->m_asio_receiving_msg,
 		[=, this](boost::system::error_code _error_code, std::size_t _length)

--- a/src/Nsocket_tcp.cpp
+++ b/src/Nsocket_tcp.cpp
@@ -165,13 +165,6 @@ void CGDK::asio::Nsocket_tcp::process_receive_async()
 	// 2) hold receiving buffer(비동기 receive 처기가 완료 될 때까지 buffer가 할당해제 되지 않도록 하기 위해 hold)
 	this->m_hold_receiving = this->m_received_msg.get_source();
 
-	// lock) 
-	std::lock_guard cs(this->m_lock_socket);
-
-	// check) 
-	if (this->m_socket.is_open() == false)
-		throw std::runtime_error("socket closed");
-
 	// 3) send async
 	this->m_socket.async_read_some(this->m_asio_receiving_msg,
 		[=, this](boost::system::error_code _error_code, std::size_t _length)
@@ -281,7 +274,17 @@ void CGDK::asio::Nsocket_tcp::process_receive_async()
 				}
 
 				// - read 
-				this->process_receive_async();
+				{
+					// - lock
+					std::lock_guard cs(this->m_lock_socket);
+
+					// check) 
+					if (this->m_socket.is_open() == false)
+						throw std::runtime_error("socket closed");
+
+					// - async receive
+					this->process_receive_async();
+				}
 			}
 			catch (...)
 			{

--- a/src/Nsocket_tcp_async_gather.cpp
+++ b/src/Nsocket_tcp_async_gather.cpp
@@ -106,7 +106,7 @@ bool CGDK::asio::Nsocket_tcp_async_gather::process_send(SEND_NODE&& _send_node)
 	}
 	catch (...)
 	{
-		// reraise) 
+		// - set false 
 		result = false;
 	}
 

--- a/src/Nsocket_tcp_async_gather.cpp
+++ b/src/Nsocket_tcp_async_gather.cpp
@@ -127,8 +127,6 @@ void CGDK::asio::Nsocket_tcp_async_gather::process_send_gather_async(const SEND_
 	this->m_socket.async_write_some(buffer_transfer,
         [=, this](boost::system::error_code ec, std::size_t /*length*/)
         {
-
-
 			// check) 
 			if (ec)
 			{

--- a/src/Nsocket_tcp_async_gather.cpp
+++ b/src/Nsocket_tcp_async_gather.cpp
@@ -75,7 +75,7 @@ bool CGDK::asio::Nsocket_tcp_async_gather::process_send(SEND_NODE&& _send_node)
 	// declare)
 	bool result = true;
 
-	try
+	try 
 	{
 		// lock) 
 		std::unique_lock lock(this->m_lock_socket);


### PR DESCRIPTION
linux에서 수신 중 접속 종료가 발생할 경우 오류가 발생하는 버그를 수정했습니다.
windows에서는 발생하지 않고 linux에서만 발생하던 문제였습니다.
close한 socket을 비동기 수신할 경우 crush를 발생시키는 오류가 있었습니다.
이 부분을 lock처리해서 오류를 수정했습니다.